### PR TITLE
Fix port output of the deployment

### DIFF
--- a/blfabrstmplt-s02.json
+++ b/blfabrstmplt-s02.json
@@ -452,7 +452,7 @@
     },
     "sshCommand": {
       "type": "string",
-      "value": "[format('ssh {0}@{1}', parameters('adminUsername'), reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))).dnsSettings.fqdn)]"
+      "value": "[format('ssh {0}@{1}', parameters('adminUsername'), reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))).dnsSettings.fqdn),'-p 2222']"
     }
   }
 }

--- a/blfabrstmplt-s02.json
+++ b/blfabrstmplt-s02.json
@@ -452,7 +452,7 @@
     },
     "sshCommand": {
       "type": "string",
-      "value": "[format('ssh {0}@{1}', parameters('adminUsername'), reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))).dnsSettings.fqdn),'-p 2222']"
+      "value": "[format('ssh {0}@{1} -p 2222', parameters('adminUsername'), reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))).dnsSettings.fqdn)]"
     }
   }
 }


### PR DESCRIPTION
As the customData contains a script which change the default ssh port to 2222. This change should be displayed in the output of the deployment
![image](https://user-images.githubusercontent.com/77504106/173165374-e7c66bc5-dd0e-484f-a9ca-a9972a6b1358.png)
