### PR TITLE
Fixing version of SLES image

### DIFF
--- a/blfabrstmplt-s04.json
+++ b/blfabrstmplt-s04.json
@@ -523,8 +523,7 @@
           "imageReference": {
             "publisher": "SUSE",
             "offer": "sles-sap-12-sp5",
-            "sku": "gen1",
-            "version": "2021.09.13"
+            "sku": "gen1"
           },
           "dataDisks": [
             {

--- a/blfabrstmplt-s04.json
+++ b/blfabrstmplt-s04.json
@@ -523,7 +523,8 @@
           "imageReference": {
             "publisher": "SUSE",
             "offer": "sles-sap-12-sp5",
-            "sku": "gen1"
+            "sku": "gen1",
+            "version": "latest"
           },
           "dataDisks": [
             {

--- a/blfabrstmplt-s05.json
+++ b/blfabrstmplt-s05.json
@@ -487,7 +487,7 @@
             "publisher": "SUSE",
             "offer": "sles-sap-12-sp5",
             "sku": "gen1",
-            "version": "2022.10.15"
+            "version": "latest"
           }
         },
         "networkProfile": {

--- a/blfabrstmplt-s05.json
+++ b/blfabrstmplt-s05.json
@@ -487,7 +487,7 @@
             "publisher": "SUSE",
             "offer": "sles-sap-12-sp5",
             "sku": "gen1",
-            "version": "2021.09.13"
+            "version": "2022.10.15"
           }
         },
         "networkProfile": {


### PR DESCRIPTION
SLES version 2021.09.13 no longer available. Making latest the default version to use